### PR TITLE
PM-381 - handle dockerfile dependency confusion issue

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Use the base image with Node.js
-FROM node:latest
+FROM node:11.15.0
 
 RUN useradd -m -s /bin/bash appuser
 


### PR DESCRIPTION
Sets a fixed version for the docker container build. `11.15.0 ` was picked because it was released around the time the docker file was initially created. 